### PR TITLE
database: Move to database/systems.db and container mount the dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 node_modules
-systems.sqlitedb
+database/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules
-systems.sqlitedb
+node_modules/
+database/

--- a/EDDN.js
+++ b/EDDN.js
@@ -12,7 +12,7 @@ const sock = zmq.socket('sub');
 const request = require('request');
 const moment = require('moment');
 const path = require('path');
-const db = new Database('systems.sqlitedb');
+const db = new Database('database/systems.db');
 
 const util = require('util');
 

--- a/allTicks.js
+++ b/allTicks.js
@@ -3,7 +3,7 @@ const Database = require('better-sqlite3');
 const moment = require('moment');
 const path = require('path');
 const clustering = require('density-clustering');
-const db = new Database('systems.sqlitedb');
+const db = new Database('database/systems.db');
 
 const util = require('util');
 

--- a/detector.js
+++ b/detector.js
@@ -10,7 +10,7 @@ const zlib = require('zlib');
 const request = require('request');
 const moment = require('moment');
 const path = require('path');
-const db = new Database('systems.sqlitedb');
+const db = new Database('database/systems.db');
 
 const util = require('util');
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,15 +5,15 @@ services:
     ports:
       - "9001:9001"
     volumes:
-      - ./systems.sqlitedb:/app/systems.sqlitedb
+      - ./database/:/app/database:rw
     command: node tick.js
   eddn:
     build: .
     volumes:
-      - ./systems.sqlitedb:/app/systems.sqlitedb
+      - ./database/:/app/database:rw
     command: node EDDN.js
   detector:
     build: .
     volumes:
-      - ./systems.sqlitedb:/app/systems.sqlitedb
+      - ./database/:/app/database:rw
     command: node detector.js

--- a/tick.js
+++ b/tick.js
@@ -29,7 +29,7 @@ const io = require('socket.io')(http, {
 });
 
 const port = 9001;
-const db = new Database('systems.sqlitedb');
+const db = new Database('database/systems.db');
 const json2html = require('node-json2html');
 
 const util = require('util');


### PR DESCRIPTION
* This way the containers share the extra files with sqlite's journal
  WAL mode.  This should avoid any corruption issues.
* The file was renamed to `systems.db` because that's the extension that
  bash completion expects for sqlite3 files, as per the latter's manual
  page.
* Explicitly tagging `database/` as `rw` in docker-compose.yml to be
  sure no-one gets the bright idea to make it read-only "for security".
  All three containers need read-write access.
  
Closes #5 