### PR TITLE
docker-compose: Set containers to restart unless explicitly stopped

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,13 +7,22 @@ services:
     volumes:
       - ./database/:/app/database:rw
     command: node tick.js
+    # Without this the container stops if containerd stops, and doesn't
+    # start when containerd is started again.
+    restart: unless-stopped
   eddn:
     build: .
     volumes:
       - ./database/:/app/database:rw
     command: node EDDN.js
+    # Without this the container stops if containerd stops, and doesn't
+    # start when containerd is started again.
+    restart: unless-stopped
   detector:
     build: .
     volumes:
       - ./database/:/app/database:rw
     command: node detector.js
+    # Without this the container stops if containerd stops, and doesn't
+    # start when containerd is started again.
+    restart: unless-stopped


### PR DESCRIPTION
This morning I restarted containerd (recommended by Debian `needs-restart` after some package upgrades), and that stopped the containers, but then didn't start them again when containerd came back up.

With this `restart: unless-stopped` it still stops the containers, but immediately starts them again, even before containerd is (re-)started.

@SayakMukhopadhyay - is this the correct thing to not have the "containerd restarted, now my containers are stopped" ?